### PR TITLE
New Macro - description(), addNullableForeign()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
             "CLNQCDRS\\Blueprint\\Macro\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "CLNQCDRS\\Blueprint\\Macro\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "illuminate/database": "^5.5",
         "illuminate/support": "^5.5",

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -18,9 +18,12 @@ class Blueprint implements MacroContract
     public static function registerMacros()
     {
         DefaultBlueprint::macro('addForeign', function ($key, $table) {
-            $this->unsignedInteger($key)
-                ->index()
-                ->nullable();
+            return $this->unsignedInteger($key)
+                ->index();
+        });
+
+        DefaultBlueprint::macro('addNullableForeign', function ($key, $table) {
+            return $this->addForeign($key, $table)->nullable();
         });
 
         DefaultBlueprint::macro('referenceOn', function ($key, $table, $references = 'id') {
@@ -47,6 +50,10 @@ class Blueprint implements MacroContract
         DefaultBlueprint::macro('label', function () {
             $this->string('label')->nullable();
             $this->string('name')->nullable();
+        });
+
+        DefaultBlueprint::macro('description', function () {
+            $this->text('description')->nullable();
         });
 
         DefaultBlueprint::macro('expired', function () {

--- a/tests/AvailableMacroTest.php
+++ b/tests/AvailableMacroTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use CLNQCDRS\Blueprint\Macro\Tests\TestCase;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ *
+ */
+class AvailableMacroTest extends TestCase
+{
+    /** @test */
+    public function it_has_add_foreign()
+    {
+        $this->assertTrue(Blueprint::hasMacro('addForeign'));
+    }
+
+    /** @test */
+    public function it_has_add_nullable_foreign()
+    {
+        $this->assertTrue(Blueprint::hasMacro('addNullableForeign'));
+    }
+
+    /** @test */
+    public function it_has_reference_on()
+    {
+        $this->assertTrue(Blueprint::hasMacro('referenceOn'));
+    }
+
+    /** @test */
+    public function it_has_add_acceptance()
+    {
+        $this->assertTrue(Blueprint::hasMacro('addAcceptance'));
+    }
+
+    /** @test */
+    public function it_has_hashslug()
+    {
+        $this->assertTrue(Blueprint::hasMacro('hashslug'));
+    }
+
+    /** @test */
+    public function it_has_slug()
+    {
+        $this->assertTrue(Blueprint::hasMacro('slug'));
+    }
+
+    /** @test */
+    public function it_has_description()
+    {
+        $this->assertTrue(Blueprint::hasMacro('description'));
+    }
+
+    /** @test */
+    public function it_has_expired()
+    {
+        $this->assertTrue(Blueprint::hasMacro('expired'));
+    }
+
+    /** @test */
+    public function it_has_user()
+    {
+        $this->assertTrue(Blueprint::hasMacro('user'));
+    }
+
+    /** @test */
+    public function it_has_amount()
+    {
+        $this->assertTrue(Blueprint::hasMacro('amount'));
+    }
+
+    /** @test */
+    public function it_has_small_amount()
+    {
+        $this->assertTrue(Blueprint::hasMacro('smallAmount'));
+    }
+
+    /** @test */
+    public function it_has_standard_time()
+    {
+        $this->assertTrue(Blueprint::hasMacro('standardTime'));
+    }
+}

--- a/tests/AvailableMacroTest.php
+++ b/tests/AvailableMacroTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace CLNQCDRS\Blueprint\Macro\Tests;
+
 use CLNQCDRS\Blueprint\Macro\Tests\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/tests/HashslugTest.php
+++ b/tests/HashslugTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CLNQCDRS\Blueprint\Macro\Tests;
+
+use CLNQCDRS\Blueprint\Macro\Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+
+class HashslugTest extends TestCase
+{
+    /** @test */
+    public function it_has_hashslug_table()
+    {
+        $this->assertTrue(Schema::hasTable('hashslug'));
+    }
+
+    /** @test */
+    public function it_has_hashslug_column()
+    {
+        $this->assertTrue(Schema::hasColumn('hashslug', 'hashslug'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CLNQCDRS\Blueprint\Macro\Tests;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->withFactories(__DIR__ . '/factories');
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        // $this->artisan('migrate', ['--database' => 'testbench']);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            \CLNQCDRS\Blueprint\Macro\BlueprintMacroServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        // Setup default database to use sqlite :memory:
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,9 +11,10 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
-        $this->withFactories(__DIR__ . '/factories');
-        $this->loadLaravelMigrations(['--database' => 'testbench']);
-        // $this->artisan('migrate', ['--database' => 'testbench']);
+        $this->artisan('migrate', [
+            '--database' => 'testbench',
+            '--path'     => realpath(__DIR__ . '/database/migrations'),
+        ]);
     }
 
     protected function getPackageProviders($app)

--- a/tests/database/migrations/2014_10_12_000000_create_hashslug_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_hashslug_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateHashslugTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('hashslug', function (Blueprint $table) {
+            $table->hashslug();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('hashslug');
+    }
+}


### PR DESCRIPTION
Added two new macro:

```php
$table->description();
$table->addNullableForeign('user_id', 'users');
```

The previous `$table->addForeign()` macro will not have the nullable value.

Also, I have created tests for this package - to test available macros.