### PR TITLE
add `BelongsTo` macro to use the same `Elqouent` naming convention

### DIFF
--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -32,6 +32,13 @@ class Blueprint implements MacroContract
                 ->on($table);
         });
 
+        DefaultBlueprint::macro('belongsTo', function ($key, $table, $references = 'id') {
+            $this->unsignedInteger($key)->index();
+            return $this->foreign($key)
+                ->references($references)
+                ->on($table);
+        });
+
         DefaultBlueprint::macro('addAcceptance', function ($value) {
             $this->boolean('is_' . $value)->default(false);
             $this->datetime($value . '_at')->nullable();

--- a/tests/AvailableMacroTest.php
+++ b/tests/AvailableMacroTest.php
@@ -17,6 +17,12 @@ class AvailableMacroTest extends TestCase
     }
 
     /** @test */
+    public function it_has_belongs_to()
+    {
+        $this->assertTrue(Blueprint::hasMacro('belongsTo'));
+    }
+
+    /** @test */
     public function it_has_add_nullable_foreign()
     {
         $this->assertTrue(Blueprint::hasMacro('addNullableForeign'));


### PR DESCRIPTION
I keep the `referenceOn` macro and add `BelongsTo` beside it to keep the BC of the package

this pull requests closes #2 