### PR TITLE
More macros and update.

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,36 @@
+<?php
+ini_set('memory_limit','1024M');
+$finder = PhpCsFixer\Finder::create()
+    ->notPath('bootstrap/cache')
+    ->notPath('storage')
+    ->notPath('vendor')
+    ->notPath('node_modules')
+    ->in(__DIR__)
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony'                          => true,
+        'class_definition'                  => [
+            'multiLineExtendsEachSingleLine' => true,
+        ],
+        'ordered_class_elements'            => [
+            'use_trait', 'constant_public', 'constant_protected', 'constant_private', 
+            'property_public', 'property_protected', 'property_private', 'construct', 
+            'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 
+            'method_private'
+        ],
+        'binary_operator_spaces'            => ['default' => 'align_single_space_minimal'],
+        'array_syntax'                      => ['syntax' => 'short'],
+        'concat_space'                      => ['spacing' => 'one'],
+        'blank_line_after_namespace'        => true,
+        'linebreak_after_opening_tag'       => true,
+        'not_operator_with_successor_space' => true,
+        'ordered_imports'                   => true,
+        'phpdoc_order'                      => true,
+    ))
+    ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+### v1.6.1 - 11/06/2018
+
+- Allow overwrite column name for `description($label)`
+- Allow nullable `user($nullable)`
+- Allow overwrite column name for reference and increase default length from 32 to 64: `reference($label, $length)`
+- Set default length for hashslug is 64 characters, and add as index
+- Allow `label()` name to be overwrite
+- Added indexing on `slug()`
+- Added `nullableBelongsTo('fk_id', 'fk_table')`
+- Added `code()`
+- Added `status()`
+- Added `is('active')`
+- Added `ordering()`
+- Added `percent()`

--- a/src/BlueprintMacroServiceProvider.php
+++ b/src/BlueprintMacroServiceProvider.php
@@ -8,8 +8,6 @@ class BlueprintMacroServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application services.
-     *
-     * @return void
      */
     public function boot()
     {
@@ -18,11 +16,8 @@ class BlueprintMacroServiceProvider extends ServiceProvider
 
     /**
      * Register the application services.
-     *
-     * @return void
      */
     public function register()
     {
-        //
     }
 }

--- a/src/Contracts/MacroContract.php
+++ b/src/Contracts/MacroContract.php
@@ -3,7 +3,7 @@
 namespace CleaniqueCoders\Blueprint\Macro\Contracts;
 
 /**
- * MacroContract
+ * MacroContract.
  */
 interface MacroContract
 {

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -40,6 +40,14 @@ class Blueprint implements MacroContract
                 ->on($table);
         });
 
+        DefaultBlueprint::macro('nullableBelongsTo', function ($key, $table, $references = 'id') {
+            $this->addNullableForeign($key);
+
+            return $this->foreign($key)
+                ->references($references)
+                ->on($table);
+        });
+
         DefaultBlueprint::macro('uuid', function ($length = 64) {
             return $this->string('uuid', $length);
         });
@@ -69,24 +77,31 @@ class Blueprint implements MacroContract
             return $this->text($value)->nullable();
         });
 
-        DefaultBlueprint::macro('hashslug', function () {
-            return $this->string('hashslug')->nullable()->unique();
+        DefaultBlueprint::macro('hashslug', function ($length = 64) {
+            return $this->string('hashslug')
+                ->length($length)
+                ->nullable()
+                ->unique()
+                ->index();
         });
 
         DefaultBlueprint::macro('slug', function () {
-            return $this->string('slug')->nullable()->unique();
+            return $this->string('slug')
+                ->nullable()
+                ->unique()
+                ->index();
         });
 
-        DefaultBlueprint::macro('label', function () {
-            return $this->string('label')->nullable();
+        DefaultBlueprint::macro('label', function ($label = 'label') {
+            return $this->string($label)->nullable();
         });
 
         DefaultBlueprint::macro('name', function ($value = 'name') {
             return $this->string($value)->nullable();
         });
 
-        DefaultBlueprint::macro('description', function () {
-            return $this->text('description')->nullable();
+        DefaultBlueprint::macro('description', function ($label = 'description') {
+            return $this->text($label)->nullable();
         });
 
         DefaultBlueprint::macro('expired', function () {
@@ -96,9 +111,13 @@ class Blueprint implements MacroContract
             return $this;
         });
 
-        DefaultBlueprint::macro('user', function () {
-            $this->belongsTo('user_id', 'users');
-
+        DefaultBlueprint::macro('user', function ($nullable = false) {
+            if($nullable) {
+                $this->nullableBelongsTo('user_id', 'users');
+            } else {
+                $this->belongsTo('user_id', 'users');
+            }
+            
             return $this;
         });
 
@@ -114,7 +133,7 @@ class Blueprint implements MacroContract
                 ->default(0);
         });
 
-        DefaultBlueprint::macro('reference', function ($length = 32) {
+        DefaultBlueprint::macro('reference', function ($label = 'reference', $length = 64) {
             return $this->string('reference', $length)
                 ->nullable()
                 ->unique()
@@ -124,6 +143,30 @@ class Blueprint implements MacroContract
         DefaultBlueprint::macro('standardTime', function () {
             $this->softDeletes();
             $this->timestamps();
+        });
+
+        DefaultBlueprint::macro('code', function ($key = 'code', $length = 20) {
+            return $this->string($key, $length)
+                ->nullable()
+                ->unique()
+                ->index();
+        });
+
+        DefaultBlueprint::macro('status', function ($key = 'status', $default = true) {
+            return $this->boolean($key)->default($default);
+        });
+
+        DefaultBlueprint::macro('is', function ($key = 'active', $default = true) {
+            return $this->status('is_' . $key, $default);
+        });
+
+        DefaultBlueprint::macro('ordering', function ($key = 'ordering', $length = 10) {
+            return $this->string($key, $length)
+                ->nullable();
+        });
+
+        DefaultBlueprint::macro('percent', function ($key = 'percent') {
+            return $this->decimal($key, 5, 2)->default(0);
         });
     }
 }

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -6,12 +6,12 @@ use CleaniqueCoders\Blueprint\Macro\Contracts\MacroContract;
 use Illuminate\Database\Schema\Blueprint as DefaultBlueprint;
 
 /**
- * Extended Blueprint by using Macro
+ * Extended Blueprint by using Macro.
  */
 class Blueprint implements MacroContract
 {
     /**
-     * Register Macros
+     * Register Macros.
      *
      * @void
      */
@@ -34,6 +34,7 @@ class Blueprint implements MacroContract
 
         DefaultBlueprint::macro('belongsTo', function ($key, $table, $references = 'id') {
             $this->addForeign($key);
+
             return $this->foreign($key)
                 ->references($references)
                 ->on($table);
@@ -48,6 +49,7 @@ class Blueprint implements MacroContract
             $this->actedAt($value . '_at');
             $this->actedBy($value . '_by');
             $this->remarks($value . '_remarks');
+
             return $this;
         });
 
@@ -90,11 +92,13 @@ class Blueprint implements MacroContract
         DefaultBlueprint::macro('expired', function () {
             $this->boolean('is_expired')->default(false);
             $this->datetime('expired_at')->nullable();
+
             return $this;
         });
 
         DefaultBlueprint::macro('user', function () {
             $this->belongsTo('user_id', 'users');
+
             return $this;
         });
 

--- a/tests/AvailableMacroTest.php
+++ b/tests/AvailableMacroTest.php
@@ -2,12 +2,8 @@
 
 namespace CleaniqueCoders\Blueprint\Macro\Tests;
 
-use CleaniqueCoders\Blueprint\Macro\Tests\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 
-/**
- *
- */
 class AvailableMacroTest extends TestCase
 {
     /** @test */

--- a/tests/AvailableMacroTest.php
+++ b/tests/AvailableMacroTest.php
@@ -7,128 +7,20 @@ use Illuminate\Database\Schema\Blueprint;
 class AvailableMacroTest extends TestCase
 {
     /** @test */
-    public function it_has_add_foreign()
+    public function it_has_extended_blueprint()
     {
-        $this->assertTrue(Blueprint::hasMacro('addForeign'));
-    }
+        $macros = [
+            'addForeign', 'addNullableForeign',
+            'referenceOn', 'belongsTo', 'nullableBelongsTo',
+            'uuid', 'addAcceptance', 'actedStatus', 
+            'actedAt', 'actedBy', 'remarks', 'hashslug',
+            'slug', 'label', 'name', 'description', 'expired',
+            'user', 'amount', 'smallAmount', 'reference', 'standardTime',
+            'code', 'status', 'is', 'ordering', 'percent',
+        ];
 
-    /** @test */
-    public function it_has_belongs_to()
-    {
-        $this->assertTrue(Blueprint::hasMacro('belongsTo'));
-    }
-
-    /** @test */
-    public function it_has_add_nullable_foreign()
-    {
-        $this->assertTrue(Blueprint::hasMacro('addNullableForeign'));
-    }
-
-    /** @test */
-    public function it_has_reference_on()
-    {
-        $this->assertTrue(Blueprint::hasMacro('referenceOn'));
-    }
-
-    /** @test */
-    public function it_has_uuid()
-    {
-        $this->assertTrue(Blueprint::hasMacro('uuid'));
-    }
-
-    /** @test */
-    public function it_has_add_acceptance()
-    {
-        $this->assertTrue(Blueprint::hasMacro('addAcceptance'));
-    }
-
-    /** @test */
-    public function it_has_acted_status()
-    {
-        $this->assertTrue(Blueprint::hasMacro('actedStatus'));
-    }
-
-    /** @test */
-    public function it_has_acted_at()
-    {
-        $this->assertTrue(Blueprint::hasMacro('actedAt'));
-    }
-
-    /** @test */
-    public function it_has_acted_by()
-    {
-        $this->assertTrue(Blueprint::hasMacro('actedBy'));
-    }
-
-    /** @test */
-    public function it_has_remarks()
-    {
-        $this->assertTrue(Blueprint::hasMacro('remarks'));
-    }
-
-    /** @test */
-    public function it_has_hashslug()
-    {
-        $this->assertTrue(Blueprint::hasMacro('hashslug'));
-    }
-
-    /** @test */
-    public function it_has_slug()
-    {
-        $this->assertTrue(Blueprint::hasMacro('slug'));
-    }
-
-    /** @test */
-    public function it_has_label()
-    {
-        $this->assertTrue(Blueprint::hasMacro('label'));
-    }
-
-    /** @test */
-    public function it_has_name()
-    {
-        $this->assertTrue(Blueprint::hasMacro('name'));
-    }
-
-    /** @test */
-    public function it_has_description()
-    {
-        $this->assertTrue(Blueprint::hasMacro('description'));
-    }
-
-    /** @test */
-    public function it_has_expired()
-    {
-        $this->assertTrue(Blueprint::hasMacro('expired'));
-    }
-
-    /** @test */
-    public function it_has_user()
-    {
-        $this->assertTrue(Blueprint::hasMacro('user'));
-    }
-
-    /** @test */
-    public function it_has_amount()
-    {
-        $this->assertTrue(Blueprint::hasMacro('amount'));
-    }
-
-    /** @test */
-    public function it_has_small_amount()
-    {
-        $this->assertTrue(Blueprint::hasMacro('smallAmount'));
-    }
-
-    /** @test */
-    public function it_has_reference()
-    {
-        $this->assertTrue(Blueprint::hasMacro('reference'));
-    }
-
-    /** @test */
-    public function it_has_standard_time()
-    {
-        $this->assertTrue(Blueprint::hasMacro('standardTime'));
+        foreach ($macros as $macro) {
+            $this->assertTrue(Blueprint::hasMacro($macro));
+        }
     }
 }

--- a/tests/ForeignTest.php
+++ b/tests/ForeignTest.php
@@ -2,7 +2,6 @@
 
 namespace CleaniqueCoders\Blueprint\Macro\Tests;
 
-use CleaniqueCoders\Blueprint\Macro\Tests\TestCase;
 use Illuminate\Support\Facades\Schema;
 
 class ForeignTest extends TestCase

--- a/tests/HashslugTest.php
+++ b/tests/HashslugTest.php
@@ -2,7 +2,6 @@
 
 namespace CleaniqueCoders\Blueprint\Macro\Tests;
 
-use CleaniqueCoders\Blueprint\Macro\Tests\TestCase;
 use Illuminate\Support\Facades\Schema;
 
 class HashslugTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,9 +17,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
     }
 
     /**
-     * Get Package Providers
-     * @param  app $app App
-     * @return array  List of service providers
+     * Get Package Providers.
+     *
+     * @param app $app App
+     *
+     * @return array List of service providers
      */
     protected function getPackageProviders($app)
     {
@@ -32,8 +34,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
+     * @param \Illuminate\Foundation\Application $app
      */
     protected function getEnvironmentSetUp($app)
     {

--- a/tests/database/migrations/2014_10_12_000000_create_foreign_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_foreign_table.php
@@ -8,8 +8,6 @@ class CreateForeignTable extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
     public function up()
     {
@@ -23,8 +21,6 @@ class CreateForeignTable extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down()
     {

--- a/tests/database/migrations/2014_10_12_000000_create_hashslug_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_hashslug_table.php
@@ -8,8 +8,6 @@ class CreateHashslugTable extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
     public function up()
     {
@@ -20,8 +18,6 @@ class CreateHashslugTable extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down()
     {


### PR DESCRIPTION
- Allow overwrite column name for `description($label)`
- Allow nullable `user($nullable)`
- Allow overwrite column name for reference and increase default length from 32 to 64: `reference($label, $length)`
- Set default length for hashslug is 64 characters, and add as index
- Allow `label()` name to be overwrite
- Added indexing on `slug()`
- Added `nullableBelongsTo('fk_id', 'fk_table')`
- Added `code()`
- Added `status()`
- Added `is('active')`
- Added `ordering()`
- Added `percent()`