### PR TITLE
Version 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,161 +4,23 @@
 
 ## Installation
 
-1. In order to install Blueprint Macro in your Laravel project:
+In order to install Blueprint Macro in your Laravel project:
 
 ```
 $ composer require cleaniquecoders/blueprint-macro
 ```
 
-2. Then in your `config/app.php` add the following to the `providers` key:
+You can skip following steps if you are on Laravel 5.5 and above.
+
+In your `config/app.php` add the following to the `providers` key:
 
 ```php
-\CleaniqueCoders\BlueprintMacro\BlueprintMacroServiceProvider::class,
+CleaniqueCoders\Blueprint\Macro\BlueprintMacroServiceProvider::class,
 ```
 
 ## Usage
 
-Available macros:
-
-1. Add Foreign Key (FK) - Normally we need to add foreign key to a table, and it's quite long and hard to maintain across your migrations.
-
-```php
-$table->addForeign('user_id', 'users');
-```
-
-> Please take note, this is for `unsignedInteger`. Contribution much appreciated to support all other common data type use for foreign key.
-
-2. Add Nullable Foreign Key (FK) - There's situation when your FK need to nullable. So this macro is for your, similar usage as `addForeign` macro.
-
-```php
-$table->addNullableForeign('user_id', 'users');
-```
-
-3. Reference On - This macro is to setup the reference of the FK.
-
-```php
-$table->referenceOn('user_id', 'users');
-```
-
-4. UUID - Another type of identifier for a resource. Default length is 64. But you may pass a length for the first argument.
-
-```php
-$table->uuid(128);
-```
-
-5. Add Acceptance - Usually when get approval, verification, certification or requests, we have some sort of basic information we want to store. For instance, when I want to apply a leave, I want to store is it accepted or not, at what time it is approved or reject, who's the approver? and possibily some remarks. So `addAcceptance` can be read as `is_approved`, `approved_at`, `approved_by` and `approved_remarks`.
-
-Basically it will create for columns with it's own responsbility:
-
-1. `is_` - A boolean type, good for quick check, true or false.
-2. `_at` - A date time type, good for storing when the event occured.
-3. `_by` - A FK to users table by default intention, but you may add `referenceOn` to other table if you need to. This is basically to know who did the acceptance.
-4. `_remarks` - Of course, a remark for the event.
-
-```php
-$table->addAcceptance('approved');
-$table->addAcceptance('rejected');
-$table->addAcceptance('applied');
-```
-
-6. Acted Status - Determine the status of the act, simply true or false.
-
-```php
-$table->actedStatus('is_approved');
-$table->actedStatus('is_rejected');
-$table->actedStatus('activated');
-```
-
-7. Acted At - You want to store date time of the act event.
-
-```php
-$table->actedAt('approved_at');
-$table->actedAt('rejected_at');
-$table->actedAt('activated_at');
-```
-
-8. Acted By - You want to store who's did that action.
-
-```php
-$table->actedBy('approved_by');
-$table->actedBy('rejected_by');
-$table->actedBy('activated_by');
-```
-
-9. Remarks - Store remarks, you may override default field name by passing the field name at first argument.
-
-```php
-$table->remarks();
-$table->remarks('approved_remark');
-```
-
-10. Hashslug - You probably want store the hashed slug, useful if you don't want to rely on incremental id or you want a unique and randomised identifier.
-
-```php
-$table->hashslug();
-```
-
-11. Slug - Store slug format (`something-like-this`) in your table.
-
-```php
-$table->slug();
-```
-
-12. Label 
-
-```php
-$table->label();
-```
-
-13. Name 
-
-```php
-$table->name();
-$table->name('first_name');
-$table->name('last_name');
-```
-
-13. Description
-
-```php
-$table->description();
-```
-
-14. Expired - Expiry fields.
-
-```php
-$table->expired();
-```
-
-15. User - most common FK setup with Reference.
-
-```php
-$table->user();
-```
-
-16. Amount - Use this for money. Optionally can set other field name.
-
-```php
-$table->amount('fee');
-```
-
-17. Small Amount - Use for money, but with smaller range.
-
-```php
-$table->smallAmount('discount');
-```
-
-18. Reference - You may want to have reference field for your documents.
-
-```php
-$table->reference();
-```
-
-19. Standard Time - consist of `softDeletes()` and `timestamps()`
-
-```php
-$table->standardTime();
-```
+See [wiki](https://github.com/cleaniquecoders/blueprint-macro/wiki/Available-Blueprint-Macros) for more details.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,19 @@
         "php": ">=7.1",
         "illuminate/database": "^5.5|^5.6",
         "illuminate/support": "^5.5|^5.6",
-        "illuminate/auth": "^5.5|^5.6"
+        "illuminate/auth": "^5.5|^5.6",
+        "doctrine/dbal": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5|^7.0",
         "orchestra/testbench": "3.5.*|3.6.*",
         "codedungeon/phpunit-result-printer": "^0.4.4|^0.6.0"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "CleaniqueCoders\\Blueprint\\Macro\\BlueprintMacroServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,365 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "75b48953c03e51ff582979e31f76c361",
+    "content-hash": "027a9c95b01ad160d9d69e7465987ccd",
     "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-12-06T07:11:42+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^5.7",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-08-25T07:02:50+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-07-22T10:37:32+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-08-31T08:43:38+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "11037b4352c008373561dc6fc836834eed80c3b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/11037b4352c008373561dc6fc836834eed80c3b5",
+                "reference": "11037b4352c008373561dc6fc836834eed80c3b5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.7.1",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                "symfony/console": "^2.0.5||^3.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2018-04-07T18:44:18+00:00"
+        },
         {
             "name": "doctrine/inflector",
             "version": "v1.3.0",

--- a/tests/ForeignTest.php
+++ b/tests/ForeignTest.php
@@ -3,7 +3,13 @@
 namespace CleaniqueCoders\Blueprint\Macro\Tests;
 
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
+/**
+ * @todo test default & custom reference
+ * @todo test bigInteger & integer
+ * @todo test nullable
+ */
 class ForeignTest extends TestCase
 {
     /** @test */
@@ -13,9 +19,26 @@ class ForeignTest extends TestCase
     }
 
     /** @test */
-    public function it_has_foreign_columns()
+    public function it_has_default_foreign_key_name()
     {
         $this->assertTrue(Schema::hasColumn('foreign', 'user_id'));
-        $this->assertTrue(Schema::hasColumn('foreign', 'supervisor_id'));
+    }
+
+    /** @test */
+    public function it_has_custom_foreign_key_name()
+    {
+        $this->assertTrue(Schema::hasColumn('foreign', 'customer_id'));
+    }
+
+    /** @test */
+    public function it_has_foreign_key_unsignedInteger()
+    {
+        $this->assertEquals(Schema::getColumnType('foreign', 'user_id'), 'integer');
+    }
+
+    /** @test */
+    public function it_has_foreign_key_unsignedBigInteger()
+    {
+        $this->assertEquals(Schema::getColumnType('foreign', 'big_id'), 'integer');
     }
 }

--- a/tests/database/migrations/2014_10_12_000000_create_big_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_big_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBigTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('bigs', function (Blueprint $table) {
+            $table->unsignedBigInteger('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('bigs');
+    }
+}

--- a/tests/database/migrations/2014_10_12_000000_create_foreign_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_foreign_table.php
@@ -12,10 +12,9 @@ class CreateForeignTable extends Migration
     public function up()
     {
         Schema::create('foreign', function (Blueprint $table) {
-            $table->addForeign('user_id', 'users');
-            $table->addNullableForeign('supervisor_id', 'users');
-            $table->referenceOn('user_id', 'users');
-            $table->referenceOn('supervisor_id', 'users');
+            $table->addForeign('users');
+            $table->addForeign('users', ['fk' => 'customer_id']);
+            $table->addForeign('bigs', ['bigInteger' => true]);
         });
     }
 


### PR DESCRIPTION
The new version 2.0 include major refactor on `addForeign` macro.

Now you don't need to specify the FK name in first argument, instead you can just pass the table name.

```php
$table->addForeign('users');
```

Above code are equivalent to previous implementation:

```php
$table->addForeign('user_id', 'users');
```

`addForeign` now accept 2nd argument as an array - list of options.

Options available

- `fk`: If you need custom FK name instead of standard Laravel naming convention for FK
- `nullable` - If you need the FK to be nullable
- `bigInteger` - If your main table use Big Integer
- `reference` - If you need foreign reference ID is other than default `id`

More details will be available in Wiki.