### PR TITLE
Swap table and key argument to allow auto guess the FK name.

### DIFF
--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -57,12 +57,18 @@ class Blueprint implements MacroContract
                 ->on($table);
         });
 
-        DefaultBlueprint::macro('belongsTo', function ($key, $table, $reference = 'id') {
+        DefaultBlueprint::macro('belongsTo', function ($table, $key = null, $reference = 'id') {
+            if(is_null($key)) {
+                $key = Str::lower(Str::singular($table)) . '_id';
+            }
             return $this->addForeign($table, ['fk' => $key, 'reference' => $reference]);
         });
 
-        DefaultBlueprint::macro('nullableBelongsTo', function ($key, $table, $reference = 'id') {
-            return $this->addNullableForeign($table, ['nullable' => true, 'fk' => $key, 'reference' => $reference]);
+        DefaultBlueprint::macro('nullableBelongsTo', function ($table, $key = null, $reference = 'id') {
+            if(is_null($key)) {
+                $key = Str::lower(Str::singular($table)) . '_id';
+            }
+            return $this->addNullableForeign($table, $key);
         });
 
         /*

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -58,16 +58,18 @@ class Blueprint implements MacroContract
         });
 
         DefaultBlueprint::macro('belongsTo', function ($table, $key = null, $reference = 'id') {
-            if(is_null($key)) {
+            if (is_null($key)) {
                 $key = Str::lower(Str::singular($table)) . '_id';
             }
+
             return $this->addForeign($table, ['fk' => $key, 'reference' => $reference]);
         });
 
         DefaultBlueprint::macro('nullableBelongsTo', function ($table, $key = null, $reference = 'id') {
-            if(is_null($key)) {
+            if (is_null($key)) {
                 $key = Str::lower(Str::singular($table)) . '_id';
             }
+
             return $this->addNullableForeign($table, $key);
         });
 


### PR DESCRIPTION
Now you can omit the FK argument when using `belongsTo` and `nullableBelongsTo` as the argument for table and key has been swapped from:

```php
$table->nullableBelongsTo('account_id', 'accounts');
```

to 

```php
$table->nullableBelongsTo('accounts', 'account_id'); // or alternatively
$table->nullableBelongsTo('accounts'); // the macro will determine the FK name automatically based on table name, following Laravel standard naming convention for FK
```


