### PR TITLE
Improve Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 cache:
   directories:
@@ -9,7 +10,7 @@ cache:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update --prefer-source --no-interaction --dev
+  - travis_retry composer update --prefer-source --no-interaction
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
# Changed log

- Add `php-7.4` version test during Travis CI build.
- Removing `--dev` option for `composer update --prefer-source --no-interaction` command. And deprecated message is as follows:

```
You are using the deprecated option "--dev". It has no effect and will break in Composer 3.
```